### PR TITLE
Tag handlers

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -575,7 +575,7 @@ func (d *decoder) scalar(n *Node, out reflect.Value) bool {
 		}
 		toSet:=reflect.ValueOf(result)
 		if toSet.CanConvert(out.Type()) {
-			out.Set(toSet)
+			out.Set(toSet.Convert(out.Type()))
 			return true
 		} else {
 			fail(fmt.Errorf("error on handle %s tag: can't convert %s to target type %s", n.Tag,

--- a/decode.go
+++ b/decode.go
@@ -568,8 +568,11 @@ func (d *decoder) null(out reflect.Value) bool {
 func (d *decoder) scalar(n *Node, out reflect.Value) bool {
 	var tag string
 	var resolved interface{}
-	if handler,ok:=d.tagHandlers[n.Tag]; ok {
-		result:=handler(n.Value)
+	if handler, ok := d.tagHandlers[n.Tag]; ok {
+		result, err := handler(n.Value)
+		if err != nil {
+			fail(err)
+		}
 		toSet:=reflect.ValueOf(result)
 		if toSet.CanConvert(out.Type()) {
 			out.Set(toSet)

--- a/decode.go
+++ b/decode.go
@@ -325,6 +325,8 @@ type decoder struct {
 	aliasDepth  int
 
 	mergedFields map[interface{}]bool
+
+	tagHandlers map[string]TagHandler
 }
 
 var (
@@ -342,6 +344,7 @@ func newDecoder() *decoder {
 		stringMapType:  stringMapType,
 		generalMapType: generalMapType,
 		uniqueKeys:     true,
+		tagHandlers: map[string]TagHandler{},
 	}
 	d.aliases = make(map[*Node]bool)
 	return d
@@ -565,6 +568,17 @@ func (d *decoder) null(out reflect.Value) bool {
 func (d *decoder) scalar(n *Node, out reflect.Value) bool {
 	var tag string
 	var resolved interface{}
+	if handler,ok:=d.tagHandlers[n.Tag]; ok {
+		result:=handler(n.Value)
+		toSet:=reflect.ValueOf(result)
+		if toSet.CanConvert(out.Type()) {
+			out.Set(toSet)
+			return true
+		} else {
+			fail(fmt.Errorf("error on handle %s tag: can't convert %s to target type %s", n.Tag,
+				toSet.Type().Name(), out.Type().Name()))
+		}
+	}
 	if n.indicatedString() {
 		tag = strTag
 		resolved = n.Value

--- a/decode_test.go
+++ b/decode_test.go
@@ -25,8 +25,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lelvisl/yaml/v3"
 	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v3"
 )
 
 var unmarshalIntTest = 123
@@ -947,7 +947,7 @@ var unmarshalErrorTests = []struct {
 	{"%TAG !%79! tag:yaml.org,2002:\n---\nv: !%79!int '1'", "yaml: did not find expected whitespace"},
 	{"a:\n  1:\nb\n  2:", ".*could not find expected ':'"},
 	{"a: 1\nb: 2\nc 2\nd: 3\n", "^yaml: line 3: could not find expected ':'$"},
-	{"#\n-\n{", "yaml: line 3: could not find expected ':'"}, // Issue #665
+	{"#\n-\n{", "yaml: line 3: could not find expected ':'"},   // Issue #665
 	{"0: [:!00 \xef", "yaml: incomplete UTF-8 octet sequence"}, // Issue #666
 	{
 		"a: &a [00,00,00,00,00,00,00,00,00]\n" +
@@ -1482,7 +1482,7 @@ func (s *S) TestMergeNestedStruct(c *C) {
 	// 2) A simple implementation might attempt to handle the key skipping
 	//    directly by iterating over the merging map without recursion, but
 	//    there are more complex cases that require recursion.
-	// 
+	//
 	// Quick summary of the fields:
 	//
 	// - A must come from outer and not overriden
@@ -1498,7 +1498,7 @@ func (s *S) TestMergeNestedStruct(c *C) {
 		A, B, C int
 	}
 	type Outer struct {
-		D, E      int
+		D, E   int
 		Inner  Inner
 		Inline map[string]int `yaml:",inline"`
 	}
@@ -1516,10 +1516,10 @@ func (s *S) TestMergeNestedStruct(c *C) {
 	// Repeat test with a map.
 
 	var testm map[string]interface{}
-	var wantm = map[string]interface {} {
-		"f":     60,
+	var wantm = map[string]interface{}{
+		"f": 60,
 		"inner": map[string]interface{}{
-		    "a": 10,
+			"a": 10,
 		},
 		"d": 40,
 		"e": 50,

--- a/encode_test.go
+++ b/encode_test.go
@@ -26,8 +26,8 @@ import (
 	"net"
 	"os"
 
+	"github.com/lelvisl/yaml/v3"
 	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v3"
 )
 
 var marshalIntTest = 123

--- a/example_embedded_test.go
+++ b/example_embedded_test.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"log"
 
-	"gopkg.in/yaml.v3"
+	"github.com/lelvisl/yaml/v3"
 )
 
 // An example showing how to unmarshal embedded

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gopkg.in/yaml.v3
+module github.com/lelvisl/yaml/v3
 
 go 1.20
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module "gopkg.in/yaml.v3"
+module gopkg.in/yaml.v3
 
-require (
-	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
-)
+go 1.20
+
+require gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/limit_test.go
+++ b/limit_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/lelvisl/yaml/v3"
 	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v3"
 )
 
 var limitTests = []struct {

--- a/node_test.go
+++ b/node_test.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/lelvisl/yaml/v3"
 	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v3"
 	"io"
 	"strings"
 )
@@ -688,17 +688,17 @@ var nodeTests = []struct {
 					Line:        3,
 					Column:      4,
 				}, {
-					Kind:   yaml.ScalarNode,
-					Tag:    "!!str",
-					Value:  "c",
+					Kind:        yaml.ScalarNode,
+					Tag:         "!!str",
+					Value:       "c",
 					LineComment: "# IC",
-					Line:   5,
-					Column: 1,
+					Line:        5,
+					Column:      1,
 				}, {
-					Kind:        yaml.SequenceNode,
-					Tag:         "!!seq",
-					Line:        6,
-					Column:      3,
+					Kind:   yaml.SequenceNode,
+					Tag:    "!!seq",
+					Line:   6,
+					Column: 3,
 					Content: []*yaml.Node{{
 						Kind:   yaml.ScalarNode,
 						Tag:    "!!str",
@@ -707,17 +707,17 @@ var nodeTests = []struct {
 						Column: 5,
 					}},
 				}, {
-					Kind:   yaml.ScalarNode,
-					Tag:    "!!str",
-					Value:  "d",
+					Kind:        yaml.ScalarNode,
+					Tag:         "!!str",
+					Value:       "d",
 					LineComment: "# ID",
-					Line:   7,
-					Column: 1,
+					Line:        7,
+					Column:      1,
 				}, {
-					Kind:        yaml.MappingNode,
-					Tag:         "!!map",
-					Line:        8,
-					Column:      3,
+					Kind:   yaml.MappingNode,
+					Tag:    "!!map",
+					Line:   8,
+					Column: 3,
 					Content: []*yaml.Node{{
 						Kind:   yaml.ScalarNode,
 						Tag:    "!!str",

--- a/yaml.go
+++ b/yaml.go
@@ -17,8 +17,7 @@
 //
 // Source code and other details for the project are available at GitHub:
 //
-//   https://github.com/go-yaml/yaml
-//
+//	https://github.com/go-yaml/yaml
 package yaml
 
 import (
@@ -75,29 +74,32 @@ type Marshaler interface {
 //
 // For example:
 //
-//     type T struct {
-//         F int `yaml:"a,omitempty"`
-//         B int
-//     }
-//     var t T
-//     yaml.Unmarshal([]byte("a: 1\nb: 2"), &t)
+//	type T struct {
+//	    F int `yaml:"a,omitempty"`
+//	    B int
+//	}
+//	var t T
+//	yaml.Unmarshal([]byte("a: 1\nb: 2"), &t)
 //
 // See the documentation of Marshal for the format of tags and a list of
 // supported tag options.
-//
 func Unmarshal(in []byte, out interface{}) (err error) {
 	return unmarshal(in, out, false)
 }
 
 // A Decoder reads and decodes YAML values from an input stream.
 type Decoder struct {
-	parser      *parser
-	knownFields bool
-	tagHandlers map[string]TagHandler
+	parser       *parser
+	knownFields  bool
+	tagResolvers map[string]TagResolver
+	tagReplacers map[string]TagReplacer
 }
 
-// TagHandler resolves value by tag in a field.
-type TagHandler func(value string) (resolvedValue interface{}, err error)
+// TagResolver resolves value by tag in a field.
+type TagResolver func(value string) (resolvedValue interface{}, err error)
+
+// TagReplacer replace a value of scalaer node before resolving.
+type TagReplacer func(value string) (replacedValue string, err error)
 
 // NewDecoder returns a new decoder that reads from r.
 //
@@ -105,8 +107,9 @@ type TagHandler func(value string) (resolvedValue interface{}, err error)
 // data from r beyond the YAML values requested.
 func NewDecoder(r io.Reader) *Decoder {
 	return &Decoder{
-		parser: newParserFromReader(r),
-		tagHandlers: map[string]TagHandler{},
+		parser:       newParserFromReader(r),
+		tagResolvers: map[string]TagResolver{},
+		tagReplacers: map[string]TagReplacer{},
 	}
 }
 
@@ -116,9 +119,14 @@ func (dec *Decoder) KnownFields(enable bool) {
 	dec.knownFields = enable
 }
 
-// SetTagHandler set handlers for custom tags in yaml document.
-func (dec *Decoder) SetTagHandler(tag string, handler TagHandler) {
-	dec.tagHandlers[tag] = handler
+// SetTagResolver set resolver func for custom tags in **scalar** yaml nodes.
+func (dec *Decoder) SetTagResolver(tag string, resolver TagResolver) {
+	dec.tagResolvers[tag] = resolver
+}
+
+// SetTagReplacers set replacer func for custom tags in **scalar** yaml nodes.
+func (dec *Decoder) SetTagReplacer(tag string, replacer TagReplacer) {
+	dec.tagReplacers[tag] = replacer
 }
 
 // Decode reads the next YAML-encoded value from its input
@@ -129,7 +137,8 @@ func (dec *Decoder) SetTagHandler(tag string, handler TagHandler) {
 func (dec *Decoder) Decode(v interface{}) (err error) {
 	d := newDecoder()
 	d.knownFields = dec.knownFields
-	d.tagHandlers = dec.tagHandlers
+	d.tagResolvers = dec.tagResolvers
+	d.tagReplacers = dec.tagReplacers
 	defer handleErr(&err)
 	node := dec.parser.parse()
 	if node == nil {
@@ -196,36 +205,35 @@ func unmarshal(in []byte, out interface{}, strict bool) (err error) {
 //
 // The field tag format accepted is:
 //
-//     `(...) yaml:"[<key>][,<flag1>[,<flag2>]]" (...)`
+//	`(...) yaml:"[<key>][,<flag1>[,<flag2>]]" (...)`
 //
 // The following flags are currently supported:
 //
-//     omitempty    Only include the field if it's not set to the zero
-//                  value for the type or to empty slices or maps.
-//                  Zero valued structs will be omitted if all their public
-//                  fields are zero, unless they implement an IsZero
-//                  method (see the IsZeroer interface type), in which
-//                  case the field will be excluded if IsZero returns true.
+//	omitempty    Only include the field if it's not set to the zero
+//	             value for the type or to empty slices or maps.
+//	             Zero valued structs will be omitted if all their public
+//	             fields are zero, unless they implement an IsZero
+//	             method (see the IsZeroer interface type), in which
+//	             case the field will be excluded if IsZero returns true.
 //
-//     flow         Marshal using a flow style (useful for structs,
-//                  sequences and maps).
+//	flow         Marshal using a flow style (useful for structs,
+//	             sequences and maps).
 //
-//     inline       Inline the field, which must be a struct or a map,
-//                  causing all of its fields or keys to be processed as if
-//                  they were part of the outer struct. For maps, keys must
-//                  not conflict with the yaml keys of other struct fields.
+//	inline       Inline the field, which must be a struct or a map,
+//	             causing all of its fields or keys to be processed as if
+//	             they were part of the outer struct. For maps, keys must
+//	             not conflict with the yaml keys of other struct fields.
 //
 // In addition, if the key is "-", the field is ignored.
 //
 // For example:
 //
-//     type T struct {
-//         F int `yaml:"a,omitempty"`
-//         B int
-//     }
-//     yaml.Marshal(&T{B: 2}) // Returns "b: 2\n"
-//     yaml.Marshal(&T{F: 1}} // Returns "a: 1\nb: 0\n"
-//
+//	type T struct {
+//	    F int `yaml:"a,omitempty"`
+//	    B int
+//	}
+//	yaml.Marshal(&T{B: 2}) // Returns "b: 2\n"
+//	yaml.Marshal(&T{F: 1}} // Returns "a: 1\nb: 0\n"
 func Marshal(in interface{}) (out []byte, err error) {
 	defer handleErr(&err)
 	e := newEncoder()
@@ -369,22 +377,21 @@ const (
 //
 // For example:
 //
-//     var person struct {
-//             Name    string
-//             Address yaml.Node
-//     }
-//     err := yaml.Unmarshal(data, &person)
-// 
+//	var person struct {
+//	        Name    string
+//	        Address yaml.Node
+//	}
+//	err := yaml.Unmarshal(data, &person)
+//
 // Or by itself:
 //
-//     var person Node
-//     err := yaml.Unmarshal(data, &person)
-//
+//	var person Node
+//	err := yaml.Unmarshal(data, &person)
 type Node struct {
 	// Kind defines whether the node is a document, a mapping, a sequence,
 	// a scalar value, or an alias to another node. The specific data type of
 	// scalar nodes may be obtained via the ShortTag and LongTag methods.
-	Kind  Kind
+	Kind Kind
 
 	// Style allows customizing the apperance of the node in the tree.
 	Style Style
@@ -431,7 +438,6 @@ func (n *Node) IsZero() bool {
 	return n.Kind == 0 && n.Style == 0 && n.Tag == "" && n.Value == "" && n.Anchor == "" && n.Alias == nil && n.Content == nil &&
 		n.HeadComment == "" && n.LineComment == "" && n.FootComment == "" && n.Line == 0 && n.Column == 0
 }
-
 
 // LongTag returns the long form of the tag that indicates the data type for
 // the node. If the Tag field isn't explicitly defined, one will be computed

--- a/yaml.go
+++ b/yaml.go
@@ -97,7 +97,7 @@ type Decoder struct {
 }
 
 // TagHandler resolves value by tag in a field.
-type TagHandler func(value string) (resolvedValue interface{})
+type TagHandler func(value string) (resolvedValue interface{}, err error)
 
 // NewDecoder returns a new decoder that reads from r.
 //


### PR DESCRIPTION
Add initial support of custom tag handlers for scalar values


example code:
```go
package main

import (
	"fmt"
	"gopkg.in/yaml.v3"
	"log"
	"os"
	"strings"
)

var data = `
a: !envstring SECRET
b: 
  c: 85
  d: [3, 4]
`

func main() {
	os.Setenv("SECRET", "pass")
	fmt.Println("hi")
	var foo struct {
		A string
		B interface{}
	}
	dec := yaml.NewDecoder(strings.NewReader(data))
	dec.SetTagHandler("!envstring", EnvTagHandler{}.Handle)
	err := dec.Decode(&foo)
	if err != nil {
		log.Fatal(err)
	}
	fmt.Println(foo)
	fmt.Println(foo.A)
}

type EnvTagHandler struct{}

func (e EnvTagHandler) Handle(str string) (any, error) {
	return os.Getenv(str), nil
}
```


In future all default tags can be implemented as tag handlers. 